### PR TITLE
Campaign - reorganized population data in front end

### DIFF
--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -90,6 +90,7 @@ class Speech extends React.Component {
     countSupporters = () => {
         let count = 0;
         Object.keys(this.props.population).forEach((province) => {
+            let numSupporters = 0;
             this.props.population[province]['citizens'].forEach((citizen) => {
                 let difference_score = 0;
                 for (const topic of Object.keys(this.state.speechProposal)) {
@@ -100,10 +101,11 @@ class Speech extends React.Component {
                     citizen.will_support = false;
                 } else {
                     citizen.will_support = true;
-                    this.props.population[province]['totalSupporters'] += 1;
+                    numSupporters += 1;
                     count++;
                 }
             });
+            this.props.population[province]['totalSupporters'] = numSupporters;
         });
 
         this.props.updatePopulation(this.props.population);
@@ -250,22 +252,15 @@ export class CampaignView extends React.Component {
         });
     }
 
-    // updateProvinceInfo() {
-    //     const provinceInfo = { countryTotal: 0, countrySupporters: 0 };
-    //     for (const citizen of this.state.populationData.citizen_list) {
-    //         const province = citizen['province'];
-    //         if (!(province in provinceInfo)) {
-    //             provinceInfo[province] = { totalPeople: 0, totalSupporters: 0 };
-    //         }
-    //         provinceInfo[province]['totalPeople']++;
-    //         provinceInfo['countryTotal']++;
-    //         if (citizen.will_support) {
-    //             provinceInfo[province]['totalSupporters']++;
-    //             provinceInfo['countrySupporters']++;
-    //         }
-    //     }
-    //     this.setState({ provinceInfo });
-    // }
+    countTotalSupport() {
+        let totalSupport = 0;
+        let totalPopulation = 0;
+        Object.values(this.state.populationData).forEach((province) => {
+            totalSupport += province['totalSupporters'];
+            totalPopulation += province['citizens'].length;
+        });
+        return { totalSupport: totalSupport, totalPopulation: totalPopulation };
+    }
 
     handleProvinceMapClick(e, province) {
         const tagname = e.target.tagName;
@@ -305,8 +300,9 @@ export class CampaignView extends React.Component {
             );
         }
         const { clickedProvince } = this.state;
-        const { provinceInfo } = this.state;
+        // const { provinceInfo } = this.state;
         const { populationData } = this.state;
+        const aggregateResult = this.countTotalSupport();
         return (
             <>
                 <h1>Campaign Game</h1><hr/>
@@ -342,9 +338,9 @@ export class CampaignView extends React.Component {
                                 : <div className={'province-info-text'}>
                                     <b>{this.state.countryName}</b>
                                     <br/>
-                                    {provinceInfo['countrySupporters']}
+                                    {aggregateResult['totalSupport']}
                                     &nbsp;out of&nbsp;
-                                    {provinceInfo['countryTotal']}
+                                    {aggregateResult['totalPopulation']}
                                     &nbsp;people support you.
                                 </div>
                             }

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -246,7 +246,6 @@ export class CampaignView extends React.Component {
     }
 
     updatePopulation(newPopulation) {
-        // this.setState({ populationData }, () => this.updateProvinceInfo());
         this.setState({
             populationData: newPopulation,
         });
@@ -299,9 +298,7 @@ export class CampaignView extends React.Component {
                 />
             );
         }
-        const { clickedProvince } = this.state;
-        // const { provinceInfo } = this.state;
-        const { populationData } = this.state;
+        const { clickedProvince, populationData } = this.state;
         const aggregateResult = this.countTotalSupport();
         return (
             <>


### PR DESCRIPTION
We thought it would be easier and more efficient to store the population as a dictionary mapping provinces to a citizen list and supporter count. Prior to this, we used two separate states. One to store a list of all citizens in a given country, and the second to store a dictionary that maps provinces to supporter counts and population size. This caused us to have to look through the same data multiple times. 

(Making this PR now so the rest of the team can use the up-to-date data)

