### PR TITLE
Campaign -- Citizen visualization

### DIFF
--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -2,7 +2,6 @@ import React from 'react';
 import * as PropTypes from 'prop-types';
 import Popover from 'react-bootstrap/Popover';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import PopoverContent from 'react-bootstrap/PopoverContent';
 import { project_features_and_create_svg_paths } from '../common';
 import { MapPath } from '../UILibrary/components';
 import './campaign.scss';
@@ -239,6 +238,9 @@ class Citizen extends React.Component {
     render() {
         const description = (
             <Popover id='popover-basic'>
+                <Popover.Title>
+                    Preferences for {this.props.data.name}
+                </Popover.Title>
                 <Popover.Content>
                     {this.generateDescription()}
                 </Popover.Content>
@@ -268,6 +270,55 @@ class Citizen extends React.Component {
 Citizen.propTypes = {
     data: PropTypes.object,
 };
+
+class SamplePopulation extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            sampleSize: Math.min(this.props.citizens.length, 50),
+        };
+    }
+
+    changeSampleSize = (e, inputMax) => {
+        const newVal = e.target.value;
+        if (newVal === '' || parseInt(newVal) < inputMax) {
+            this.setState({
+                sampleSize: e.target.value,
+            });
+        } else {
+            this.setState({
+                sampleSize: inputMax,
+            });
+        }
+    };
+
+
+    render() {
+        return (
+            <div>
+                <div>
+                    Sample Size:
+                    <input
+                        type="number"
+                        name="sampleSize"
+                        step="1"
+                        min="0"
+                        max={this.props.citizens.length}
+                        value={this.state.sampleSize}
+                        onChange={(e) => this.changeSampleSize(e, this.props.citizens.length)}
+                    />
+                </div>
+                <div>
+
+                </div>
+            </div>
+    );
+    }
+}
+SamplePopulation.propTypes = {
+    citizens: PropTypes.array,
+};
+
 
 export class CampaignView extends React.Component {
     constructor(props) {

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -329,7 +329,7 @@ export class CampaignView extends React.Component {
             clickedProvince: null,
             countryName: 'South Africa',
             resultsData: null,
-            view: '',
+            view: 'intro',
             sampleSize: 50,
         };
         this.map_height = 500;

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -256,12 +256,12 @@ class Citizen extends React.Component {
                     height='20'
                     width='20'
                 >
-                     <circle
+                    <circle
                         cx='10'
                         cy='10'
                         r='10'
                         fill={this.props.data.will_support ? 'green' : '#c0c0c0'}
-                     />
+                    />
                 </svg>
             </OverlayTrigger>
         );
@@ -454,7 +454,7 @@ export class CampaignView extends React.Component {
         let citizenReactions;
         if (populationData && clickedProvince) {
             const citizens = populationData[clickedProvince]['citizens'];
-            const sample = citizens.slice(0, this.state.sampleSize);
+            const sample = citizens.slice(0, sampleSize);
             citizenReactions = sample.map((citizen, k) => (
                 <Citizen key={k} data={citizen}/>
             ));
@@ -473,7 +473,7 @@ export class CampaignView extends React.Component {
                         step="1"
                         min="0"
                         max={citizens.length}
-                        value={this.state.sampleSize}
+                        value={sampleSize}
                         onChange={(e) => this.changeSampleSize(e, citizens.length)}
                     />
                 </div>

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -271,54 +271,6 @@ Citizen.propTypes = {
     data: PropTypes.object,
 };
 
-class SamplePopulation extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            sampleSize: Math.min(this.props.citizens.length, 50),
-        };
-    }
-
-    changeSampleSize = (e, inputMax) => {
-        const newVal = e.target.value;
-        if (newVal === '' || parseInt(newVal) < inputMax) {
-            this.setState({
-                sampleSize: e.target.value,
-            });
-        } else {
-            this.setState({
-                sampleSize: inputMax,
-            });
-        }
-    };
-
-
-    render() {
-        return (
-            <div>
-                <div>
-                    Sample Size:
-                    <input
-                        type="number"
-                        name="sampleSize"
-                        step="1"
-                        min="0"
-                        max={this.props.citizens.length}
-                        value={this.state.sampleSize}
-                        onChange={(e) => this.changeSampleSize(e, this.props.citizens.length)}
-                    />
-                </div>
-                <div>
-
-                </div>
-            </div>
-    );
-    }
-}
-SamplePopulation.propTypes = {
-    citizens: PropTypes.array,
-};
-
 
 export class CampaignView extends React.Component {
     constructor(props) {

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
+import Popover from 'react-bootstrap/Popover';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import PopoverContent from 'react-bootstrap/PopoverContent';
 import { project_features_and_create_svg_paths } from '../common';
 import { MapPath } from '../UILibrary/components';
 import './campaign.scss';
@@ -214,6 +217,58 @@ Results.propTypes = {
     countryName: PropTypes.string,
 };
 
+class Citizen extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            show: false,
+        };
+    }
+
+    generateDescription = () => {
+        const traits = this.props.data['traits'];
+        return Object.keys(traits).map((trait) => (
+            <>
+                <strong> {trait} </strong>: &nbsp;
+                {traits[trait]}
+                <br/>
+            </>
+        ));
+    };
+
+    render() {
+        const description = (
+            <Popover id='popover-basic'>
+                <Popover.Content>
+                    {this.generateDescription()}
+                </Popover.Content>
+            </Popover>
+        );
+        return (
+            <OverlayTrigger
+                overlay={description}
+                placement='right'
+            >
+                <svg
+                    className='budget-reaction-citizen'
+                    height='20'
+                    width='20'
+                >
+                     <circle
+                        cx='10'
+                        cy='10'
+                        r='10'
+                        fill={this.props.data.will_support ? 'green' : '#c0c0c0'}
+                     />
+                </svg>
+            </OverlayTrigger>
+        );
+    }
+}
+Citizen.propTypes = {
+    data: PropTypes.object,
+};
+
 export class CampaignView extends React.Component {
     constructor(props) {
         super(props);
@@ -223,12 +278,12 @@ export class CampaignView extends React.Component {
             clickedProvince: null,
             countryName: 'South Africa',
             resultsData: null,
-            view: 'intro',
+            view: '',
+            sampleSize: 50,
         };
         this.map_height = 500;
         this.map_width = 500;
         this.updatePopulation = this.updatePopulation.bind(this);
-        // this.updateProvinceInfo = this.updateProvinceInfo.bind(this);
     }
 
     async fetchPopulation() {
@@ -320,6 +375,7 @@ export class CampaignView extends React.Component {
         if (tagname === 'svg' || (tagname === 'path' && province)) {
             this.setState({
                 clickedProvince: province,
+                sampleSize: Math.min(this.state.populationData[province]['citizens'].length, 50),
             });
         }
     }
@@ -336,11 +392,24 @@ export class CampaignView extends React.Component {
         this.setState({ view: 'submitted' });
     };
 
+    changeSampleSize = (e, inputMax) => {
+        const newVal = e.target.value;
+        if (newVal === '' || parseInt(newVal) < inputMax) {
+            this.setState({
+                sampleSize: e.target.value,
+            });
+        } else {
+            this.setState({
+                sampleSize: inputMax,
+            });
+        }
+    };
+
     render() {
         if (!(this.state.populationData && this.state.mapData)) {
             return (<div>Loading!</div>);
         }
-        const { clickedProvince, populationData } = this.state;
+        const { clickedProvince, populationData, sampleSize } = this.state;
         const aggregateResult = this.countTotalSupport();
 
         if (this.state.view === 'intro') {
@@ -378,6 +447,36 @@ export class CampaignView extends React.Component {
                 </div>
             );
         }
+
+        let citizenReactions;
+        if (populationData && clickedProvince) {
+            const citizens = populationData[clickedProvince]['citizens'];
+            const sample = citizens.slice(0, this.state.sampleSize);
+            citizenReactions = sample.map((citizen, k) => (
+                <Citizen key={k} data={citizen}/>
+            ));
+        }
+
+        // TODO: refactor citizen reaction into a separate component
+        let viewSample = (<p>Click on a province to view individual results</p>);
+        if (clickedProvince) {
+            const citizens = populationData[clickedProvince]['citizens'];
+            viewSample = (
+                <div>
+                    Sample Size:
+                    <input
+                        type="number"
+                        name="sampleSize"
+                        step="1"
+                        min="0"
+                        max={citizens.length}
+                        value={this.state.sampleSize}
+                        onChange={(e) => this.changeSampleSize(e, citizens.length)}
+                    />
+                </div>
+            );
+        }
+
         return (
             <>
                 <h1>Campaign Game</h1><hr/>
@@ -443,6 +542,10 @@ export class CampaignView extends React.Component {
                                     />;
                                 })}
                             </svg>
+                            <div>
+                                {viewSample}
+                                {citizenReactions}
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Just like with budget simulator, there is now a component to represent a sample of the population to provide context/info about the type of people that voted:
- Fill color indicates whether the citizen supports
- Hovering over the svg will produce a popup with name and preferences
- Responsive to changes

![image](https://user-images.githubusercontent.com/42757189/80248903-dc47aa80-863e-11ea-85c4-6f80626c3c19.png)
![image](https://user-images.githubusercontent.com/42757189/80248960-f6818880-863e-11ea-90e5-4eb7b848b001.png)
