### PR TITLE
Add #FeesMustFall storyline to choose-your-own-adventure

### DIFF
--- a/frontend/src/chooseAdventure/chooseAdventure.js
+++ b/frontend/src/chooseAdventure/chooseAdventure.js
@@ -38,26 +38,9 @@ export class ChooseAdventureView extends React.Component {
 
 
     render() {
-        const desc = 'Paragraphs are the building blocks of papers. Many '
-            + 'students '
-            + 'define paragraphs in terms of length: a paragraph is a group of at least five '
-            + 'sentences, '
-            + 'a paragraph is half a page long, etc. In reality, though, the unity and coherence '
-            + 'of '
-            + 'ideas among sentences is what constitutes a paragraph. A paragraph is defined as '
-            + '“a '
-            + 'group of sentences or a single sentence that forms a unit” (Lunsford and Connors '
-            + '116). '
-            + 'Length and appearance do not determine whether a section in a paper is a paragraph. '
-            + 'For instance, in some styles of writing, particularly journalistic styles, a '
-            + 'paragraph '
-            + 'can be just one sentence long. Ultimately, a paragraph is a sentence or group of '
-            + 'sentences that support one main idea. In this handout, we will refer to this as the '
-            + '“controlling idea,” because it controls what happens in the rest of the paragraph.';
         return (
             <div>
                 {this.state.view === 'intro' && <IntroView
-                    desc={desc}
                     setView={this.setView}
                     imgFile={'/static/img/sample.jpg'}
                     altText={'sample image'}

--- a/frontend/src/chooseAdventure/chooseAdventure.js
+++ b/frontend/src/chooseAdventure/chooseAdventure.js
@@ -13,7 +13,6 @@ export class ChooseAdventureView extends React.Component {
         this.state = {
             view: 'intro',
             history: [],
-            successTotal: 1,
         };
     }
 
@@ -31,15 +30,8 @@ export class ChooseAdventureView extends React.Component {
         }));
     };
 
-    updateSuccess = (successFactor) => {
-        this.setState((prevState) => ({
-            successTotal: prevState.successTotal * successFactor,
-        }));
-    };
-
     resetProgress = () => {
         this.setState({
-            successTotal: 1,
             history: [],
         });
     };
@@ -72,12 +64,10 @@ export class ChooseAdventureView extends React.Component {
                 />}
                 {this.state.view === 'stage' && <StageView
                     setView={this.setView}
-                    updateSuccess={this.updateSuccess}
                     updateHistory={this.updateHistory}
                     imgFile={'/static/img/sample.jpg'}
                 />}
                 {this.state.view === 'end' && <EndView
-                    successTotal={this.state.successTotal}
                     history={this.state.history}
                     setView={this.setView}
                     resetProgress={this.resetProgress}

--- a/frontend/src/chooseAdventure/endView.js
+++ b/frontend/src/chooseAdventure/endView.js
@@ -21,15 +21,16 @@ class EndView extends React.Component {
     // };
 
     render() {
-        const choices = this.props.history.map((option, k) => (
+        const filteredHistory = this.props.history.filter((option) => option.showOnEnd);
+        const choices = filteredHistory.map((option, k) => (
             <div className={'end-option'} key={k}>
                 <strong>{option.text}</strong>
-                <br />
-                {option.successDetail}
+                {option.detail}
             </div>
         ));
         return (
             <div>
+                <div>On 23 October, Zuma announces no increase.</div>
                 <div>Your choices:</div>
                 {choices}
                 <div className='cyoa-button end-button'

--- a/frontend/src/chooseAdventure/endView.js
+++ b/frontend/src/chooseAdventure/endView.js
@@ -15,26 +15,21 @@ class EndView extends React.Component {
         this.props.resetProgress();
     };
 
-    formatAsPercentage = (probability) => {
-        const unrounded = probability * 100;
-        return unrounded.toFixed(0);
-    };
+    // formatAsPercentage = (probability) => {
+    //     const unrounded = probability * 100;
+    //     return unrounded.toFixed(0);
+    // };
 
     render() {
         const choices = this.props.history.map((option, k) => (
             <div className={'end-option'} key={k}>
                 <strong>{option.text}</strong>
                 <br />
-                This option has a {this.formatAsPercentage(option.successFactor)}%
-                 chance of success.
-                <br />
                 {option.successDetail}
             </div>
         ));
         return (
             <div>
-                <div>You had a {this.formatAsPercentage(this.props.successTotal)}%
-                    chance of succeeding.</div>
                 <div>Your choices:</div>
                 {choices}
                 <div className='cyoa-button end-button'
@@ -50,7 +45,6 @@ class EndView extends React.Component {
 EndView.propTypes = {
     setView: PropTypes.func,
     history: PropTypes.array,
-    successTotal: PropTypes.number,
     resetProgress: PropTypes.func,
 };
 

--- a/frontend/src/chooseAdventure/introView.js
+++ b/frontend/src/chooseAdventure/introView.js
@@ -12,11 +12,19 @@ class IntroView extends React.Component {
     }
 
     render() {
+        const desc = <div>You are a sophomore at Rhodes University. Reports of tuition increases
+                of up to 10.5% have come out from multiple South African universities, including
+                Rhodes. Students at the University of Witwatersrand and the University of Cape Town
+                have already begun protesting, and there are rumors floating around social media
+                about a student-led total shutdown of the Rhodes Campus. Many students are worried
+                that these higher fees will shut poorer students out of education. However,
+                other students are worried that the disruption caused by a protest will be more
+                    harmful to the ability to learn.</div>;
         return (
             <div>
                 <div className='row'>
                     <div className={'col-6'}>
-                        {this.props.desc}
+                        {desc}
                         <div className='intro-btn-container'>
                             <div className='cyoa-button start-button'
                                 onClick={() => this.props.setView('stage')}>
@@ -28,7 +36,7 @@ class IntroView extends React.Component {
                         className= 'col-6 intro-img'
                         src={this.props.imgFile}
                         alt={this.props.altText}
-                        height='600'
+                        height='400'
                     />
                 </div>
             </div>

--- a/frontend/src/chooseAdventure/stageView.js
+++ b/frontend/src/chooseAdventure/stageView.js
@@ -2,11 +2,11 @@ import React from 'react';
 import * as PropTypes from 'prop-types';
 
 const START_STAGE = {
-    'text': 'Your school district\'s budget was cut!',
+    'text': 'A friend texts you about a sit-in at the administrative offices.'
+        + ' What is your initial reaction?',
     'options': [{
-        'text': 'Start a media campaign',
+        'text': ' Agree; you want to participate!',
         'stageName': 'MEDIA_STAGE',
-        'successFactor': 0.9,
         'successDetail':
             'Since elections are taking place soon, it\'s good to raise awareness'
             + ' about your issue among potential voters.',
@@ -14,7 +14,6 @@ const START_STAGE = {
     {
         'text': 'Take direct action',
         'stageName': 'DIRECT_STAGE',
-        'successFactor': 0.1,
         'successDetail':
             'Unfortunately, the school officials are corrupt in your district, so '
             + 'direct action is not as effective.',
@@ -26,7 +25,6 @@ const MEDIA_STAGE = {
     'options': [{
         'text': 'Twitter',
         'stageName': null,
-        'successFactor': 0.8,
         'successDetail':
             'Twitter is huge in your country! You\'ve successfully raised awareness'
             + ' about your issue. ',
@@ -34,14 +32,12 @@ const MEDIA_STAGE = {
     {
         'text': 'Facebook',
         'stageName': null,
-        'successFactor': 0,
         'successDetail': 'Facebook is banned in your country, so most people can\'t see your'
             + ' posts.',
     },
     {
         'text': 'Radio',
         'stageName': null,
-        'successFactor': 0.6,
         'successDetail': 'The people who run the most popular local radio station support your'
             + ' cause, and agree to share your message with the community.',
     }],
@@ -52,14 +48,12 @@ const DIRECT_STAGE = {
     'options': [{
         'text': 'Sue the principal',
         'stageName': null,
-        'successFactor': 0.1,
         'successDetail': 'This was a joke filler option, it should be replaced with something'
             + ' else.',
     },
     {
         'text': 'Ask the principal nicely',
         'stageName': null,
-        'successFactor': 0.5,
         'successDetail': 'The principal says no and has security escort you out.',
     }],
 };
@@ -109,7 +103,6 @@ class StageView extends React.Component {
 
     setStage = (stage, option) => {
         this.props.updateHistory(option);
-        this.props.updateSuccess(option.successFactor);
         if (option.stageName) {
             this.setState({ stage: getStageFromName(option.stageName) });
         } else {
@@ -149,7 +142,6 @@ StageView.propTypes = {
     stageName: PropTypes.string,
     updateHistory: PropTypes.func,
     setView: PropTypes.func,
-    updateSuccess: PropTypes.func,
     imgFile: PropTypes.string,
 };
 

--- a/frontend/src/chooseAdventure/stageView.js
+++ b/frontend/src/chooseAdventure/stageView.js
@@ -1,67 +1,198 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
 
-const START_STAGE = {
-    'text': 'A friend texts you about a sit-in at the administrative offices.'
-        + ' What is your initial reaction?',
+const STAGE_1 = {
+    'text': <div>A friend texts you about a sit-in at the administrative offices. What is your
+        initial reaction?</div>,
     'options': [{
-        'text': ' Agree; you want to participate!',
-        'stageName': 'MEDIA_STAGE',
-        'successDetail':
-            'Since elections are taking place soon, it\'s good to raise awareness'
-            + ' about your issue among potential voters.',
+        'text': <div>Agree; you want to participate!</div>,
+        'stageName': 'STAGE_1A',
+        'detail': '',
+        'showOnEnd': true,
     },
     {
-        'text': 'Take direct action',
-        'stageName': 'DIRECT_STAGE',
-        'successDetail':
-            'Unfortunately, the school officials are corrupt in your district, so '
-            + 'direct action is not as effective.',
+        'text': <div>Agree, but you’re a little skeptical: want to learn more</div>,
+        'stageName': 'STAGE_1B_INT',
+        'detail': '',
+        'showOnEnd': true,
+    },
+    {
+        'text': <div>Disagree: you’re really not comfortable being part of this right now</div>,
+        'stageName': 'STAGE_1C_INT',
+        'detail': '',
+        'showOnEnd': true,
     }],
 };
 
-const MEDIA_STAGE = {
-    'text': 'You chose to start a media campaign.',
+const STAGE_1A = {
+    'text': <div>A friend texts you about a sit-in at the administrative offices.
+        What is your initial reaction?</div>,
     'options': [{
-        'text': 'Twitter',
-        'stageName': null,
-        'successDetail':
-            'Twitter is huge in your country! You\'ve successfully raised awareness'
-            + ' about your issue. ',
+        'text': <div>You get there, but feel the tension of the situation and are worried that the
+             sit-in might escalate from a purely peaceful protest because students
+             started blockading road access, and you decide to sneak out before things
+             get worse.</div>,
+        'stageName': 'STAGE_2',
+        'detail': '',
+        'showOnEnd': true,
     },
     {
-        'text': 'Facebook',
-        'stageName': null,
-        'successDetail': 'Facebook is banned in your country, so most people can\'t see your'
-            + ' posts.',
-    },
-    {
-        'text': 'Radio',
-        'stageName': null,
-        'successDetail': 'The people who run the most popular local radio station support your'
-            + ' cause, and agree to share your message with the community.',
+        'text': <div>You stay with the movement and help block the roads. After, you join them at
+             the sit in. The protesters occupy the admin building and things escalate! You try to
+             escape, but get caught by the riot police.</div>,
+        'stageName': 'STAGE_1AB_INT',
+        'detail': '',
+        'showOnEnd': true,
     }],
 };
 
-const DIRECT_STAGE = {
-    'text': 'You chose to take direct action against the school.',
+const STAGE_1AB_INT = {
+    'text': <div>That night, students hold an all night vigil outside the police station, calling
+        for your and your peers’ release. Thankfully, they let you go.</div>,
     'options': [{
-        'text': 'Sue the principal',
-        'stageName': null,
-        'successDetail': 'This was a joke filler option, it should be replaced with something'
-            + ' else.',
+        'text': <div>Next</div>,
+        'stageName': 'STAGE_2',
+        'detail': '',
+        'showOnEnd': false,
+    }],
+};
+
+const STAGE_1B_INT = {
+    'text': <div>
+        <p>After you’ve had a while to ponder, you decide you want to participate, but you’d prefer
+            a less confrontational route.</p>
+        <p>In the meantime, the university closes anyway.</p>
+        <p>On 19 October, the University agrees to new negotiations.</p>
+    </div>,
+    'options': [{
+        'text': <div>Next</div>,
+        'stageName': 'STAGE_2',
+        'detail': '',
+        'showOnEnd': false,
+    }],
+};
+
+const STAGE_1C_INT = {
+    'text': <div>
+        <p>In the meantime, the university closes anyway.</p>
+        <p>On 19 October, the University agrees to new negotiations.</p>
+    </div>,
+    'options': [{
+        'text': <div>Next</div>,
+        'stageName': 'STAGE_2_1C',
+        'detail': '',
+        'showOnEnd': false,
+    }],
+};
+
+const STAGE_2 = {
+    'text': <div>On 21 October, you hear about the potential march on Parliament.</div>,
+    'options': [{
+        'text': <div>Join the march</div>,
+        'stageName': 'STAGE_2A_INT',
+        'detail': <div>WITS university administration announces that no disciplinary action
+            will be taken against students and staff members who participated in the
+            protests.</div>,
+        'showOnEnd': true,
     },
     {
-        'text': 'Ask the principal nicely',
+        'text': <div>Participate by social media</div>,
+        'stageName': 'STAGE_2B_INT',
+        'detail': '',
+        'showOnEnd': true,
+    },
+    {
+        'text': <div>Do nothing</div>,
+        'stageName': 'STAGE_2C_INT',
+        'detail': '',
+        'showOnEnd': true,
+    }],
+};
+
+const STAGE_2_1C = {
+    'text': <div>On 21 October, you hear about the potential march on Parliament.</div>,
+    'options': [{
+        'text': <div>Join the march</div>,
+        'stageName': 'STAGE_2A_INT',
+        'detail': <div>WITS university administration announces that no disciplinary action
+            will be taken against students and staff members who participated in the
+            protests.</div>,
+        'showOnEnd': true,
+    },
+    {
+        'text': <div>Participate by social media</div>,
+        'stageName': 'STAGE_2B_INT',
+        'detail': '',
+        'showOnEnd': true,
+    },
+    {
+        'text': <div>Still, you’re not comfortable; you again do nothing</div>,
+        'stageName': 'STAGE_2C_INT',
+        'detail': <div>You’ve remained outside the action the whole time. But you feel
+            terrible that your friends have suffered. As they are released, you try to contact them,
+            separately and together, but you receive no response. Perhaps you’ve been affected after
+            all. </div>,
+        'showOnEnd': true,
+    }],
+};
+
+const STAGE_2A_INT = {
+    'text': <div>
+        <p>Aha. Maybe those in the government will listen. This sounds like a better opportunity
+            to have an impact; you want to join this march. (Plus you feel kind of terrible that
+            your friends got arrested.)</p>
+        <p>Just as you are wrapping up, some people in the crowd agitate the police by throwing a
+            flaming “coffin” Blade Nzimande at them, and violence breaks out.</p>
+    </div>,
+    'options': [{
+        'text': <div>Next</div>,
         'stageName': null,
-        'successDetail': 'The principal says no and has security escort you out.',
+        'detail': '',
+        'showOnEnd': false,
+    }],
+};
+
+const STAGE_2B_INT = {
+    'text': <div>
+        <p>This sounds like something others should know about! You choose to use social
+        media to share what’s happening.</p>
+        <p>You inform other people of the march on parliament and it turns out that as many as 5000
+            people showed up to protest. You feel a mixed sense of relief and horror as you hear
+            about that chaos towards the end of the march.</p>
+            </div>,
+    'options': [{
+        'text': <div>Next</div>,
+        'stageName': null,
+        'detail': '',
+        'showOnEnd': false,
+    }],
+};
+
+const STAGE_2C_INT = {
+    'text': <div>
+        <p>You’re skeptical any of this will work. It might be better to stay out of this for now.
+            So you choose to do nothing. </p>
+        <p>Given the violent end to the march, you feel satisfied with your choice to stay back.</p>
+            </div>,
+    'options': [{
+        'text': 'Next',
+        'stageName': null,
+        'detail': '',
+        'showOnEnd': false,
     }],
 };
 
 const NAME_TO_STAGE = {
-    'START_STAGE': START_STAGE,
-    'MEDIA_STAGE': MEDIA_STAGE,
-    'DIRECT_STAGE': DIRECT_STAGE,
+    'STAGE_1': STAGE_1,
+    'STAGE_1A': STAGE_1A,
+    'STAGE_1AB_INT': STAGE_1AB_INT,
+    'STAGE_1B_INT': STAGE_1B_INT,
+    'STAGE_1C_INT': STAGE_1C_INT,
+    'STAGE_2': STAGE_2,
+    'STAGE_2_1C': STAGE_2_1C,
+    'STAGE_2A_INT': STAGE_2A_INT,
+    'STAGE_2B_INT': STAGE_2B_INT,
+    'STAGE_2C_INT': STAGE_2C_INT,
 };
 
 const getStageFromName = (stageName) => {
@@ -97,7 +228,7 @@ class StageView extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            stage: getStageFromName('START_STAGE'),
+            stage: getStageFromName('STAGE_1'),
         };
     }
 

--- a/frontend/src/chooseAdventure/stageView.js
+++ b/frontend/src/chooseAdventure/stageView.js
@@ -159,7 +159,7 @@ const STAGE_2B_INT = {
         <p>You inform other people of the march on parliament and it turns out that as many as 5000
             people showed up to protest. You feel a mixed sense of relief and horror as you hear
             about that chaos towards the end of the march.</p>
-            </div>,
+    </div>,
     'options': [{
         'text': <div>Next</div>,
         'stageName': null,
@@ -173,7 +173,7 @@ const STAGE_2C_INT = {
         <p>You’re skeptical any of this will work. It might be better to stay out of this for now.
             So you choose to do nothing. </p>
         <p>Given the violent end to the march, you feel satisfied with your choice to stay back.</p>
-            </div>,
+    </div>,
     'options': [{
         'text': 'Next',
         'stageName': null,


### PR DESCRIPTION
- Added all currently-written stages from the doc 
- Added a new 'showOnEnd' field to every option 
   - This is to distinguish the 'Next' option on intermediate slides without real choices from the actual choices
- Removed successFactor and numeric calculations
- Changed text from strings to divs to accommodate formatting
- Things that appear as a result of cumulative choices (as opposed to one single choice) are handled as variations of a stage (e.g., people who chose not to do nothing for the sit-in see STAGE_2, people who chose to do nothing for the sit-in see STAGE_2_1C)
