### PR TITLE
Campaign Game Final Screen Improvements

### DIFF
--- a/frontend/src/campaign/campaign.scss
+++ b/frontend/src/campaign/campaign.scss
@@ -195,3 +195,11 @@ $edx-button-color: #e7e7e7;
         margin-bottom: 1em;
     }
 }
+
+.support {
+    color: #5abf5a;
+}
+
+.unsupport {
+    color: #db5653;
+}

--- a/frontend/src/campaign/campaign.scss
+++ b/frontend/src/campaign/campaign.scss
@@ -203,3 +203,5 @@ $edx-button-color: #e7e7e7;
 .unsupport {
     color: #db5653;
 }
+
+

--- a/frontend/src/campaign/campaign.scss
+++ b/frontend/src/campaign/campaign.scss
@@ -138,7 +138,7 @@ $edx-button-color: #e7e7e7;
     flex-direction: column;
     justify-content: space-evenly;
     align-items: center;
-    position: absolute;
+    position: fixed;
     top: 50%;
     left: 50%;
     width: 50rem;
@@ -204,4 +204,15 @@ $edx-button-color: #e7e7e7;
     color: #db5653;
 }
 
+.country-header {
+    width: 100%;
+}
+
+.country-title {
+    margin-left: 36%;
+}
+
+.close-button {
+    cursor: pointer;
+}
 

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -460,6 +460,7 @@ export class CampaignView extends React.Component {
                         mapData={this.state.mapData}
                         generateDescription={this.generateDescription}
                         map={campaign_map}
+                        clickedProvince={this.state.clickedProvince}
                     />
                     <button
                         className='campaign-btn'

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -39,7 +39,6 @@ export class CampaignView extends React.Component {
 
     calculate_averages() {
         const population = this.state.populationData;
-        console.log(this.state);
         Object.keys(population).forEach((province) => {
             Object.keys(population[province]['citizens']).forEach((citizen_name) => {
                 // eslint-disable-next-line max-len
@@ -75,7 +74,6 @@ export class CampaignView extends React.Component {
             return '';
         }
         const averages = this.state.populationData[selected_province]['averages'];
-        console.log(averages);
         if (selected_province !== '' && selected_province !== null) {
             Object.keys(averages).forEach((trait) => {
                 if (averages[trait] <= 2.5) {
@@ -84,8 +82,6 @@ export class CampaignView extends React.Component {
                     high_value.push(trait);
                 }
             });
-            console.log(low_value);
-            console.log(high_value);
             if (high_value.length === 0 && low_value.length === 0) {
                 return 'Citizens of this province are equally concerned about all of the issues.';
             }
@@ -180,7 +176,6 @@ export class CampaignView extends React.Component {
                     };
                 }
             });
-            console.log(population);
 
             const topicNames = get_country_prop(this.state.countryName, 'topicNames');
 

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -380,7 +380,6 @@ export class CampaignView extends React.Component {
                     if (this.state.round > 0
                         && this.state.populationData[country.name]) {
                         const data = this.state.populationData[country.name];
-                        /* eslint-disable-next-line max-len */
                         const supports = data['totalSupporters'] / data['citizens'].length > 0.5;
                         countryFill = supports ? '#B8E39B' : '#F19C79';
                     }
@@ -415,7 +414,7 @@ export class CampaignView extends React.Component {
                         <b>{countryName}</b>
                     </div>
                 }
-                {this.state.view === 'countryInfo'
+                {this.state.view === 'countryInfo' || this.state.view === 'feedback'
                     ? <OverlayTrigger
                         trigger="hover"
                         placement="right"
@@ -460,6 +459,7 @@ export class CampaignView extends React.Component {
                         countryName={countryName}
                         mapData={this.state.mapData}
                         generateDescription={this.generateDescription}
+                        map={campaign_map}
                     />
                     <button
                         className='campaign-btn'

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -321,9 +321,17 @@ export class CampaignView extends React.Component {
                     {this.state.showCountrySelector
                         && <CountrySelectorPopup
                             changeCountry={this.changeCountry}
-                            closePopup={() => this.setState(
-                                { showCountrySelector: false, view: 'countryInfo' },
-                            )}
+                            closePopup={(startGame) => {
+                                if (startGame) {
+                                    this.setState(
+                                        { showCountrySelector: false, view: 'countryInfo' },
+                                    );
+                                } else {
+                                    this.setState(
+                                        { showCountrySelector: false },
+                                    );
+                                }
+                            }}
                         />
                     }
                     <IntroView
@@ -462,9 +470,17 @@ export class CampaignView extends React.Component {
                     {this.state.showCountrySelector
                         && <CountrySelectorPopup
                             changeCountry={this.changeCountry}
-                            closePopup={() => this.setState(
-                                { showCountrySelector: false, view: 'countryInfo' },
-                            )}
+                            closePopup={(startGame) => {
+                                if (startGame) {
+                                    this.setState(
+                                        { showCountrySelector: false, view: 'countryInfo' },
+                                    );
+                                } else {
+                                    this.setState(
+                                        { showCountrySelector: false },
+                                    );
+                                }
+                            }}
                         />
                     }
                 </div>

--- a/frontend/src/campaign/campaignView.js
+++ b/frontend/src/campaign/campaignView.js
@@ -446,9 +446,6 @@ export class CampaignView extends React.Component {
         if (this.state.view === 'submitted') {
             return (
                 <div>
-                    <p className={'resultHeader'}>
-                        Final Results for {countryName}
-                    </p>
                     <Results
                         provinceData={populationData}
                         countryData={aggregateResult}

--- a/frontend/src/campaign/countrySelectorPopup.js
+++ b/frontend/src/campaign/countrySelectorPopup.js
@@ -5,17 +5,24 @@ import { COUNTRIES } from './speech';
 class CountrySelectorPopup extends React.Component {
     selectCountryClosePopup = (country) => {
         this.props.changeCountry(country);
-        this.props.closePopup();
+        this.props.closePopup(true);
     };
 
     render() {
         return (
             <div className='country-selector'>
-                <span className="close-button">&times;</span>
-                <h3>Select a country</h3>
+                <div className="modal-header country-header">
+                    <h3 className="country-title">Select a country</h3>
+                    <span
+                        className="close close-button"
+                        onClick={() => this.props.closePopup(false)}
+                    >
+                        &times;
+                    </span>
+                </div>
                 <div className='row w-100'>
                     {COUNTRIES.map((country, key) => (
-                        <div key={key} className='col-4'>
+                        <div key={key} className='col-sm-12 col-md-4'>
                             <div className='card' >
                                 <div className='card-header'>
                                     <h5>{country.name}</h5>

--- a/frontend/src/campaign/countrySelectorPopup.js
+++ b/frontend/src/campaign/countrySelectorPopup.js
@@ -11,6 +11,7 @@ class CountrySelectorPopup extends React.Component {
     render() {
         return (
             <div className='country-selector'>
+                <span className="close-button">&times;</span>
                 <h3>Select a country</h3>
                 <div className='row w-100'>
                     {COUNTRIES.map((country, key) => (

--- a/frontend/src/campaign/results.js
+++ b/frontend/src/campaign/results.js
@@ -34,8 +34,13 @@ class Results extends React.Component {
         const countryPercent = Math.round((this.props.countryData.totalSupport
                                                 / this.props.countryData.totalPopulation) * 100);
 
+        const winText = `Congratulations! You won! You got ${countryPercent}% of the vote.`;
+        const loseText = `Sadly, you lost. You only got ${countryPercent}% of the vote.`;
         return (
             <div>
+                <p className={'resultHeader'}>
+                    {countryPercent >= 50 ? winText : loseText}
+                </p>
                 <table border='1' className={'resultTable'}>
                     <tbody>
                         <tr>

--- a/frontend/src/campaign/results.js
+++ b/frontend/src/campaign/results.js
@@ -5,8 +5,6 @@ import Citizen from './citizen';
 class Results extends React.Component {
     constructor(props) {
         super(props);
-        this.map_height = 500;
-        this.map_width = 500;
     }
 
     render() {
@@ -17,9 +15,12 @@ class Results extends React.Component {
 
         // TODO: possibly refactor this further since it is similar to CampaignView
         const sample = [];
-        Object.values(this.props.provinceData).forEach((province) => {
-            const citizens = province['citizens'];
-            sample.push(...citizens.slice(0, Math.round(citizens.length * 0.25)));
+        Object.keys(this.props.provinceData).forEach((province) => {
+            const provinceData = this.props.provinceData[province];
+            if (province === this.props.clickedProvince || this.props.clickedProvince === '') {
+                const citizens = provinceData['citizens'];
+                sample.push(...citizens.slice(0, Math.round(citizens.length * 0.25)));
+            }
         });
         const citizens = sample.map((citizen, k) => (
             <Citizen
@@ -104,6 +105,7 @@ Results.propTypes = {
     mapData: PropTypes.array,
     generateDescription: PropTypes.func,
     map: PropTypes.object,
+    clickedProvince: PropTypes.string,
 };
 
 export default Results;

--- a/frontend/src/campaign/results.js
+++ b/frontend/src/campaign/results.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
-import { MapPath } from '../UILibrary/components';
 import Citizen from './citizen';
 
 class Results extends React.Component {
@@ -83,33 +82,7 @@ class Results extends React.Component {
                     </tbody>
                 </table>
                 <div className='campaign-result_graphics'>
-                    <svg
-                        height={this.map_height}
-                        width={this.map_width}
-                        id='content'
-                        className='result-map'
-                    >
-                        {this.props.mapData.map((province, i) => {
-                            let countryFill;
-                            if (province.name) {
-                                countryFill = resultsData[province.name].totalSupporters
-                                / resultsData[province.name].citizens.length > 0.5
-                                    ? '#5abf5a' : '#db5653';
-                            } else {
-                                countryFill = '#F6F4D2';
-                            }
-
-                            return <MapPath
-                                key={i}
-                                path={province.svg_path}
-                                id={province.postal}
-                                fill={countryFill}
-                                stroke='black'
-                                strokeWidth='1'
-                                useColorTransition={false}
-                            />;
-                        })}
-                    </svg>
+                    {this.props.map}
                     <div className='result-population'>
                         <div className='result-population_header'>
                             Results for sample population of size {sample.length}
@@ -130,6 +103,7 @@ Results.propTypes = {
     countryName: PropTypes.string,
     mapData: PropTypes.array,
     generateDescription: PropTypes.func,
+    map: PropTypes.object,
 };
 
 export default Results;

--- a/frontend/src/campaign/results.js
+++ b/frontend/src/campaign/results.js
@@ -31,6 +31,9 @@ class Results extends React.Component {
             />
         ));
 
+        const countryPercent = Math.round((this.props.countryData.totalSupport
+                                                / this.props.countryData.totalPopulation) * 100);
+
         return (
             <div>
                 <table border='1' className={'resultTable'}>
@@ -41,21 +44,30 @@ class Results extends React.Component {
                             <th>Number of People</th>
                             <th>Percentage of Votes</th>
                         </tr>
-                        {Object.keys(resultsData).map((province, k) => (
-                            (
-                                province !== 'countryTotal'
+                        {Object.keys(resultsData).map((province, k) => {
+                            if (province !== 'countryTotal'
                                 && province !== 'countrySupporters'
-                                && province !== 'countryName'
-                            )
-                            && <tr key={k}>
-                                <td>{province}</td>
-                                <td>{resultsData[province].totalSupporters}</td>
-                                <td>{resultsData[province].citizens.length}</td>
-                                <td>{Math.round((resultsData[province].totalSupporters
-                                    / resultsData[province].citizens.length) * 100)}%</td>
-                            </tr>
-                        ))}
-                        <tr className={'countryResult'}>
+                                && province !== 'countryName') {
+                                const supporters = resultsData[province].totalSupporters;
+                                const total = resultsData[province].citizens.length;
+                                const percentage = Math.round((supporters / total) * 100);
+                                return (
+                                    <tr
+                                        className={percentage >= 50 ? 'support' : 'unsupport'}
+                                        key={k}
+                                    >
+                                        <td>{province}</td>
+                                        <td>{supporters}</td>
+                                        <td>{total}</td>
+                                        <td>{percentage}%</td>
+                                    </tr>
+                                );
+                            }
+                            return (<></>);
+                        })}
+                        <tr className={`countryResult ${countryPercent >= 50
+                            ? 'support'
+                            : 'unsupport'}`}>
                             <th>{this.props.countryName}</th>
                             <th>{this.props.countryData.totalSupport}</th>
                             <th>{this.props.countryData.totalPopulation}</th>


### PR DESCRIPTION
Branched off from PR #114 
 - Matched the color of the text in the table of the final screen to whether you have over 50% of the vote from that province
- Once you get to the results screen, the user will know if they won or lost and how much votes they got.
- The try again button renders the modal, but now with a fixed position, so the modal will be in the center no matter where you scroll
- When you click on a province in the final screen, you will be able to see the name of that province as well as a sample of the citizens from that region.